### PR TITLE
PDF didn't exist so the script failed to generate files.

### DIFF
--- a/build/tools/build_pdf.pl
+++ b/build/tools/build_pdf.pl
@@ -14,6 +14,8 @@ require App::pod2pdf
 
 my $outpath = catdir( qw( build pdf ) );
 
+mkdir $outpath if ( ! -d $outpath ); 
+
 for my $chapter ( @chapters ){
     my @filename = split( /\./ , $chapter );
     print "Converting $chapter to pdf\n";


### PR DESCRIPTION
Make the PDF dir with a core command in case it didn't already exist. Maybe we should have a location check to make sure we're in the root of the project? Dunno.
